### PR TITLE
Optimize gameplay performance paths

### DIFF
--- a/Assets/DebugText.cs
+++ b/Assets/DebugText.cs
@@ -2,59 +2,64 @@ using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
+using System.Text;
 
 public class DebugText : MonoBehaviour
 {
     // Start is called before the first frame update
-    public static string max_combo = ""; // ‹LqÏ‚İ
-    public static string combo = ""; // ‹LqÏ‚İ
-    public static string max_score = ""; // ‹LqÏ‚İ
-    public static string score = ""; // ‹LqÏ‚İ
-    public static string ratioscore = ""; // ‹LqÏ‚İ
-    public static string max_score_l1 = ""; // ‹LqÏ‚İ
-    public static string max_score_l2 = ""; // ‹LqÏ‚İ
-    public static string max_score_l3 = ""; // ‹LqÏ‚İ
-    public static string max_score_l4 = ""; // ‹LqÏ‚İ
-    public static int score_l1 = 0; // ‹LqÏ‚İ
-    public static int score_l2 = 0; // ‹LqÏ‚İ
-    public static int score_l3 = 0; // ‹LqÏ‚İ
-    public static int score_l4 = 0; // ‹LqÏ‚İ
-    public static string max_l1 = ""; // ‹LqÏ‚İ
-    public static string max_l2 = ""; // ‹LqÏ‚İ
-    public static string max_l3 = ""; // ‹LqÏ‚İ
-    public static string max_l4 = ""; // ‹LqÏ‚İ
-    public static int judged_l1 = 0; // ‹LqÏ‚İ
-    public static int judged_l2 = 0; // ‹LqÏ‚İ
-    public static int judged_l3 = 0; // ‹LqÏ‚İ
-    public static int judged_l4 = 0; // ‹LqÏ‚İ
-    public static int perfect_l1 = 0; // ‹LqÏ‚İ
-    public static int perfect_l2 = 0; // ‹LqÏ‚İ
-    public static int perfect_l3 = 0; // ‹LqÏ‚İ
-    public static int perfect_l4 = 0; // ‹LqÏ‚İ
-    public static int good_l1 = 0; // ‹LqÏ‚İ
-    public static int good_l2 = 0; // ‹LqÏ‚İ
-    public static int good_l3 = 0; // ‹LqÏ‚İ
-    public static int good_l4 = 0; // ‹LqÏ‚İ
-    public static int bad_l1 = 0; // ‹LqÏ‚İ
-    public static int bad_l2 = 0; // ‹LqÏ‚İ
-    public static int bad_l3 = 0; // ‹LqÏ‚İ
-    public static int bad_l4 = 0; // ‹LqÏ‚İ
-    public static int miss_l1 = 0; // ‹LqÏ‚İ
-    public static int miss_l2 = 0; // ‹LqÏ‚İ
-    public static int miss_l3 = 0; // ‹LqÏ‚İ
-    public static int miss_l4 = 0; // ‹LqÏ‚İ
+    public static string max_combo = ""; // æœ€å¤§ã‚³ãƒ³ãƒœ
+    public static string combo = ""; // ã‚³ãƒ³ãƒœæ•°
+    public static string max_score = ""; // æœ€å¤§ã‚¹ã‚³ã‚¢
+    public static string score = ""; // ã‚¹ã‚³ã‚¢
+    public static string ratioscore = ""; // æ¯”ç‡ã‚¹ã‚³ã‚¢
+    public static string max_score_l1 = ""; // æœ€å¤§ã‚¹ã‚³ã‚¢
+    public static string max_score_l2 = ""; // æœ€å¤§ã‚¹ã‚³ã‚¢
+    public static string max_score_l3 = ""; // æœ€å¤§ã‚¹ã‚³ã‚¢
+    public static string max_score_l4 = ""; // æœ€å¤§ã‚¹ã‚³ã‚¢
+    public static int score_l1 = 0; // ã‚¹ã‚³ã‚¢
+    public static int score_l2 = 0; // ã‚¹ã‚³ã‚¢
+    public static int score_l3 = 0; // ã‚¹ã‚³ã‚¢
+    public static int score_l4 = 0; // ã‚¹ã‚³ã‚¢
+    public static string max_l1 = ""; // æœ€å¤§å€¤
+    public static string max_l2 = ""; // æœ€å¤§å€¤
+    public static string max_l3 = ""; // æœ€å¤§å€¤
+    public static string max_l4 = ""; // æœ€å¤§å€¤
+    public static int judged_l1 = 0; // åˆ¤å®šæ•°
+    public static int judged_l2 = 0; // åˆ¤å®šæ•°
+    public static int judged_l3 = 0; // åˆ¤å®šæ•°
+    public static int judged_l4 = 0; // åˆ¤å®šæ•°
+    public static int perfect_l1 = 0; // Perfect
+    public static int perfect_l2 = 0; // Perfect
+    public static int perfect_l3 = 0; // Perfect
+    public static int perfect_l4 = 0; // Perfect
+    public static int good_l1 = 0; // Good
+    public static int good_l2 = 0; // Good
+    public static int good_l3 = 0; // Good
+    public static int good_l4 = 0; // Good
+    public static int bad_l1 = 0; // Bad
+    public static int bad_l2 = 0; // Bad
+    public static int bad_l3 = 0; // Bad
+    public static int bad_l4 = 0; // Bad
+    public static int miss_l1 = 0; // Miss
+    public static int miss_l2 = 0; // Miss
+    public static int miss_l3 = 0; // Miss
+    public static int miss_l4 = 0; // Miss
 
     [SerializeField] GameObject dtxt;
+    private TextMeshProUGUI debugOutput;
+    [SerializeField] private float refreshInterval = 0.1f;
+    private float refreshTimer = 0f;
 
     public static bool isDebugMode = false;
 
     public string getDebugText()
     {
-        return dtxt.GetComponent<TextMeshProUGUI>().text;
+        return debugOutput.text;
     }
 
     void Start()
     {
+        debugOutput = dtxt.GetComponent<TextMeshProUGUI>();
         string[] args = System.Environment.GetCommandLineArgs();
         foreach (string arg in args)
         {
@@ -72,9 +77,19 @@ public class DebugText : MonoBehaviour
     {
         if (!isDebugMode)
         {
-            dtxt.GetComponent<TextMeshProUGUI>().text = "";
+            if (!string.IsNullOrEmpty(debugOutput.text))
+            {
+                debugOutput.text = "";
+            }
             return;
         }
+
+        refreshTimer += Time.unscaledDeltaTime;
+        if (refreshTimer < refreshInterval)
+        {
+            return;
+        }
+        refreshTimer = 0f;
 
         if (!adata.ready_to_start && isDebugMode)
         {
@@ -119,43 +134,46 @@ public class DebugText : MonoBehaviour
 
         if (isDebugMode && adata.ready_to_start)
         {
-            dtxt.GetComponent<TextMeshProUGUI>().text = "Max Combo = " + max_combo + "\n" +
-                "Combo = " + combo + "\n" +
-                "Max Score = " + max_score + "\n" +
-                "Score = " + score + "\n" +
-                "Ratio Score = " + ratioscore + "\n" +
-                "Max Score L1 = " + max_score_l1 + "\n" +
-                "Max Score L2 = " + max_score_l2 + "\n" +
-                "Max Score L3 = " + max_score_l3 + "\n" +
-                "Max Score L4 = " + max_score_l4 + "\n" +
-                "Score L1 = " + score_l1 + "\n" +
-                "Score L2 = " + score_l2 + "\n" +
-                "Score L3 = " + score_l3 + "\n" +
-                "Score L4 = " + score_l4 + "\n" +
-                "Max L1 = " + max_l1 + "\n" +
-                "Max L2 = " + max_l2 + "\n" +
-                "Max L3 = " + max_l3 + "\n" +
-                "Max L4 = " + max_l4 + "\n" +
-                "Judged L1 = " + judged_l1 + "\n" +
-                "Judged L2 = " + judged_l2 + "\n" +
-                "Judged L3 = " + judged_l3 + "\n" +
-                "Judged L4 = " + judged_l4 + "\n" +
-                "Perfect L1 = " + perfect_l1 + "\n" +
-                "Perfect L2 = " + perfect_l2 + "\n" +
-                "Perfect L3 = " + perfect_l3 + "\n" +
-                "Perfect L4 = " + perfect_l4 + "\n" +
-                "Good L1 = " + good_l1 + "\n" +
-                "Good L2 = " + good_l2 + "\n" +
-                "Good L3 = " + good_l3 + "\n" +
-                "Good L4 = " + good_l4 + "\n" +
-                "Bad L1 = " + bad_l1 + "\n" +
-                "Bad L2 = " + bad_l2 + "\n" +
-                "Bad L3 = " + bad_l3 + "\n" +
-                "Bad L4 = " + bad_l4 + "\n" +
-                "Miss L1 = " + miss_l1 + "\n" +
-                "Miss L2 = " + miss_l2 + "\n" +
-                "Miss L3 = " + miss_l3 + "\n" +
-                "Miss L4 = " + miss_l4 + "\n";
+            var builder = new StringBuilder();
+            builder.AppendLine("Max Combo = " + max_combo);
+            builder.AppendLine("Combo = " + combo);
+            builder.AppendLine("Max Score = " + max_score);
+            builder.AppendLine("Score = " + score);
+            builder.AppendLine("Ratio Score = " + ratioscore);
+            builder.AppendLine("Max Score L1 = " + max_score_l1);
+            builder.AppendLine("Max Score L2 = " + max_score_l2);
+            builder.AppendLine("Max Score L3 = " + max_score_l3);
+            builder.AppendLine("Max Score L4 = " + max_score_l4);
+            builder.AppendLine("Score L1 = " + score_l1);
+            builder.AppendLine("Score L2 = " + score_l2);
+            builder.AppendLine("Score L3 = " + score_l3);
+            builder.AppendLine("Score L4 = " + score_l4);
+            builder.AppendLine("Max L1 = " + max_l1);
+            builder.AppendLine("Max L2 = " + max_l2);
+            builder.AppendLine("Max L3 = " + max_l3);
+            builder.AppendLine("Max L4 = " + max_l4);
+            builder.AppendLine("Judged L1 = " + judged_l1);
+            builder.AppendLine("Judged L2 = " + judged_l2);
+            builder.AppendLine("Judged L3 = " + judged_l3);
+            builder.AppendLine("Judged L4 = " + judged_l4);
+            builder.AppendLine("Perfect L1 = " + perfect_l1);
+            builder.AppendLine("Perfect L2 = " + perfect_l2);
+            builder.AppendLine("Perfect L3 = " + perfect_l3);
+            builder.AppendLine("Perfect L4 = " + perfect_l4);
+            builder.AppendLine("Good L1 = " + good_l1);
+            builder.AppendLine("Good L2 = " + good_l2);
+            builder.AppendLine("Good L3 = " + good_l3);
+            builder.AppendLine("Good L4 = " + good_l4);
+            builder.AppendLine("Bad L1 = " + bad_l1);
+            builder.AppendLine("Bad L2 = " + bad_l2);
+            builder.AppendLine("Bad L3 = " + bad_l3);
+            builder.AppendLine("Bad L4 = " + bad_l4);
+            builder.AppendLine("Miss L1 = " + miss_l1);
+            builder.AppendLine("Miss L2 = " + miss_l2);
+            builder.AppendLine("Miss L3 = " + miss_l3);
+            builder.AppendLine("Miss L4 = " + miss_l4);
+
+            debugOutput.text = builder.ToString();
         }
     }
 }

--- a/Assets/LaneController.cs
+++ b/Assets/LaneController.cs
@@ -8,6 +8,14 @@ using UnityEngine.Events;
 
 public class LaneController : MonoBehaviour
 {
+    private static readonly Dictionary<string, int> lastCompletedNoteIdByLane = new Dictionary<string, int>
+    {
+        { "L1", -1 },
+        { "L2", -1 },
+        { "L3", -1 },
+        { "L4", -1 },
+    };
+
     [Tooltip("Set the lane number (1-4) in the Unity Editor")]
     public int laneIndex; 
 
@@ -35,6 +43,7 @@ public class LaneController : MonoBehaviour
     private JArray change;
 
     private bool LongNoteDetermined = false;
+    private bool hasRegisteredCompletion = false;
     private bool debugDataSent;
 
     // Lane-specific configurations
@@ -50,6 +59,36 @@ public class LaneController : MonoBehaviour
         InitializeLaneData();
         Init_0();
         InitializeNote();
+    }
+
+    private static bool IsPreviousNoteCompleted(string laneId, int currentId)
+    {
+        if (!lastCompletedNoteIdByLane.TryGetValue(laneId, out var lastCompleted))
+        {
+            return false;
+        }
+
+        return currentId == 0 || lastCompleted >= currentId - 1;
+    }
+
+    private void RegisterNoteCompletion()
+    {
+        if (hasRegisteredCompletion)
+        {
+            return;
+        }
+
+        if (lastCompletedNoteIdByLane.ContainsKey(laneJsonId))
+        {
+            lastCompletedNoteIdByLane[laneJsonId] = Math.Max(lastCompletedNoteIdByLane[laneJsonId], id);
+        }
+        else
+        {
+            lastCompletedNoteIdByLane[laneJsonId] = id;
+        }
+
+        hasRegisteredCompletion = true;
+        isPreviousObjectDestroyed = true;
     }
     
     private void InitializeLaneData()
@@ -186,7 +225,8 @@ public class LaneController : MonoBehaviour
         LongNoteDetermined = false;
         EndTask = false;
         debugDataSent = false;
-        isPreviousObjectDestroyed = false; // Reset this flag
+        hasRegisteredCompletion = false;
+        isPreviousObjectDestroyed = IsPreviousNoteCompleted(laneJsonId, id);
 
         return Task.CompletedTask;
     }
@@ -300,19 +340,7 @@ public class LaneController : MonoBehaviour
             // --- Previous Note Check ---
             if (!isPreviousObjectDestroyed)
             {
-                 if (id > 0)
-                 {
-                    string prev_id = (id - 1).ToString();
-                    // This check is inefficient. For better performance, use an event-based system.
-                    if (GameObject.Find($"{laneJsonId}_{prev_id}") == null && GameObject.Find($"{laneJsonId}_long_{prev_id}") == null)
-                    {
-                        isPreviousObjectDestroyed = true;
-                    }
-                 }
-                 else
-                 {
-                    isPreviousObjectDestroyed = true;
-                 }
+                isPreviousObjectDestroyed = IsPreviousNoteCompleted(laneJsonId, id);
             }
 
             if(isPreviousObjectDestroyed && !debugDataSent)
@@ -333,6 +361,7 @@ public class LaneController : MonoBehaviour
                 if (type == "tap" && (arrsec - game_time <= adata.auto))
                 {
                     ShowJudgementEffect("Perfect"); UpdateScore("Perfect");
+                    RegisterNoteCompletion();
                     await RecycleOrDestroy();
                 }
                 else if (type == "long")
@@ -346,6 +375,7 @@ public class LaneController : MonoBehaviour
                     {
                         ShowJudgementEffect("Perfect"); UpdateScore("Perfect");
                         LongNoteDetermined = true;
+                        RegisterNoteCompletion();
                         await RecycleOrDestroy();
                     }
                 }
@@ -366,11 +396,13 @@ public class LaneController : MonoBehaviour
                     else if (timelag <= adata.good) { ShowJudgementEffect("Good"); UpdateScore("Good"); }
                     else if (timelag <= adata.bad) { ShowJudgementEffect("Bad"); UpdateScore("Bad"); }
                     else { return; } // Input too early/late, ignore
+                    RegisterNoteCompletion();
                     await RecycleOrDestroy();
                 }
                 else if (game_time > arrsec + adata.miss)
                 {
                     ShowJudgementEffect("Miss"); UpdateScore("Miss");
+                    RegisterNoteCompletion();
                     await RecycleOrDestroy();
                 }
             }
@@ -414,6 +446,7 @@ public class LaneController : MonoBehaviour
 
                 if (LongNoteDetermined)
                 {
+                    RegisterNoteCompletion();
                     await RecycleOrDestroy();
                 }
             }

--- a/Assets/ShowFPS.cs
+++ b/Assets/ShowFPS.cs
@@ -8,17 +8,21 @@ public class ShowFPS : MonoBehaviour
 {
     private float fps;
     public GameObject FPSText;
-    public GameObject graphObject; // LineRenderer‚ğƒAƒ^ƒbƒ`‚·‚éƒIƒuƒWƒFƒNƒg
+    public GameObject graphObject; // LineRendererãŒã‚¢ã‚¿ãƒƒãƒã•ã‚Œã‚‹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
     private LineRenderer lineRenderer;
-    private int maxDataPoints = 100; // ƒOƒ‰ƒt‚É•\¦‚·‚éÅ‘åƒf[ƒ^“_”
-    private List<float> fpsData = new List<float>(); // FPSƒf[ƒ^‚ğŠi”[‚·‚éƒŠƒXƒg
-    private float ax = 3f; // ƒOƒ‰ƒt‚ÌX²‚ÌƒIƒtƒZƒbƒg
-    private float by = -2.4f; // ƒOƒ‰ƒt‚ÌY²‚ÌƒIƒtƒZƒbƒg
+    private int maxDataPoints = 100; // ã‚°ãƒ©ãƒ•ã«è¡¨ç¤ºã™ã‚‹æœ€å¤§ãƒ‡ãƒ¼ã‚¿ç‚¹
+    private List<float> fpsData = new List<float>(); // FPSãƒ‡ãƒ¼ã‚¿ã‚’æ ¼ç´ã™ã‚‹ãƒªã‚¹ãƒˆ
+    private float ax = 3f; // ã‚°ãƒ©ãƒ•ã®Xè»¸ã®ã‚ªãƒ•ã‚»ãƒƒãƒˆ
+    private float by = -2.4f; // ã‚°ãƒ©ãƒ•ã®Yè»¸ã®ã‚ªãƒ•ã‚»ãƒƒãƒˆ
+    private TMPro.TextMeshProUGUI fpsText;
+    private float refreshTimer = 0f;
+    [SerializeField] private float refreshInterval = 0.2f;
 
     // Start is called before the first frame update
     void Start()
     {
-        // LineRenderer‚Ì‰Šúİ’è
+        fpsText = FPSText.GetComponent<TMPro.TextMeshProUGUI>();
+        // LineRendererã®åˆæœŸè¨­å®š
         lineRenderer = graphObject.AddComponent<LineRenderer>();
         lineRenderer.material = new Material(Shader.Find("Sprites/Default"));
         lineRenderer.widthMultiplier = 0.02f;
@@ -30,22 +34,9 @@ public class ShowFPS : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        // FPSƒf[ƒ^‚ÌXV
-        fpsData.Add(fps);
-        if (fpsData.Count > maxDataPoints)
-        {
-            fpsData.RemoveAt(0); // ŒÃ‚¢ƒf[ƒ^‚ğíœ
-        }
+        fps = 1f / Time.unscaledDeltaTime;
+        refreshTimer += Time.unscaledDeltaTime;
 
-        // ƒOƒ‰ƒt‚Ì•`‰æ
-        for (int i = 0; i < fpsData.Count; i++)
-        {
-            float x = i * (graphObject.transform.localScale.x / maxDataPoints) + ax;
-            float y = fpsData[i] * (graphObject.transform.localScale.y / 100f) + by; // 100FPS‚ğÅ‘å’l‚Æ‚µ‚ÄƒXƒP[ƒŠƒ“ƒO
-            lineRenderer.SetPosition(i, new Vector3(x, y, 0));
-        }
-
-        fps = 1f / Time.deltaTime;
         if (name == "Main Camera")
         {
             if (adata.ready_to_start)
@@ -83,16 +74,46 @@ public class ShowFPS : MonoBehaviour
             }
         }
 
-        // FPS•\¦‚Ìˆ—
-        if (adata.showFPS)
+        if (refreshTimer < refreshInterval)
         {
-            FPSText.GetComponent<TextMeshProUGUI>().text = "FPS (Press F3 to invisible): " + fps;
-            graphObject.SetActive(true); // ƒOƒ‰ƒt‚ğ•\¦
+            return;
         }
-        else
+
+        refreshTimer = 0f;
+
+        if (!adata.showFPS)
         {
-            FPSText.GetComponent<TextMeshProUGUI>().text = "";
-            graphObject.SetActive(false); // ƒOƒ‰ƒt‚ğ”ñ•\¦
+            if (graphObject.activeSelf)
+            {
+                graphObject.SetActive(false);
+            }
+
+            if (!string.IsNullOrEmpty(fpsText.text))
+            {
+                fpsText.text = string.Empty;
+            }
+
+            fpsData.Clear();
+            return;
         }
+
+        graphObject.SetActive(true);
+
+        // FPSãƒ‡ãƒ¼ã‚¿ã®æ›´æ–°
+        fpsData.Add(fps);
+        if (fpsData.Count > maxDataPoints)
+        {
+            fpsData.RemoveAt(0); // å¤ã„ãƒ‡ãƒ¼ã‚¿ã‚’å‰Šé™¤
+        }
+
+        // ã‚°ãƒ©ãƒ•ã®æç”»
+        for (int i = 0; i < fpsData.Count; i++)
+        {
+            float x = i * (graphObject.transform.localScale.x / maxDataPoints) + ax;
+            float y = fpsData[i] * (graphObject.transform.localScale.y / 100f) + by; // 100FPSã‚’æœ€å¤§å€¤ã¨ã—ã¦ã‚¹ã‚±ãƒ¼ãƒªãƒ³ã‚°
+            lineRenderer.SetPosition(i, new Vector3(x, y, 0));
+        }
+
+        fpsText.text = $"FPS (Press F3 to invisible): {fps:0.0}";
     }
 }


### PR DESCRIPTION
## Summary
- eliminate per-frame scene searches for lane sequencing by tracking completed notes
- throttle FPS/debug UI updates and cache text components to reduce allocations
- keep FPS graph data handling gated by visibility to lower overhead

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69480034ca908325ad28ca3c70714fdb)